### PR TITLE
Do not require SSL to allow for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Kibana 4.4+
 bin/kibana plugin -i oauth2 -u https://github.com/trevan/oauth2/releases/download/0.1.0/oauth2-0.1.0.zip
 ```
 
-3. SSL is required so set the `server.ssl.key` and `server.ssl.cert` config options.
-
-4. Set the following config options:
+3. Set the following config options:
 ```
 oauth2.encryptionKey
 oauth2.provider
@@ -23,6 +21,8 @@ oauth2.providerSecret
 ```
 
 To get the list of supported providers, see [Bell's documentation](https://github.com/hapijs/bell)
+
+Don't forget to set the SSL key and certificate before deploying to production!
 
 ### Issues
 Please file issues [here](https://github.com/trevan/oauth2/issues).

--- a/index.js
+++ b/index.js
@@ -31,9 +31,6 @@ module.exports = function (kibana) {
       if (config.get('oauth2.provider') == null || config.get('oauth2.providerId') == null || config.get('oauth2.providerSecret') == null) {
         throw new Error('Please set oauth2.provider, oauth2.providerId, and oauth2.providerSecret in kibana.yml.');
       }
-      if (config.get('server.ssl.key') == null || config.get('server.ssl.cert') == null) {
-        throw new Error('HTTPS is required. Please set server.ssl.key and server.ssl.cert in kibana.yml.');
-      }
 
       server.register([hapiAuthCookie, Bell], function (error) {
         server.auth.strategy('session', 'cookie', 'required', {
@@ -50,7 +47,8 @@ module.exports = function (kibana) {
           provider: 'github',
           password: config.get('oauth2.encryptionKey'),
           clientId: config.get('oauth2.providerId'),
-          clientSecret: config.get('oauth2.providerSecret')
+          clientSecret: config.get('oauth2.providerSecret'),
+          isSecure: !!config.get('server.ssl.cert')
         });
       });
 


### PR DESCRIPTION
Yes you should always have an `https` oauth callback URL in production, but we have to develop code locally too. Allow for both.