### PR TITLE
Fix a crash if allowed indicies is not present by conditionally using the interceptor

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,9 @@ module.exports = function (kibana) {
         }
       });
 
-      esRequestInterceptor(server);
+      if (Array.isArray(config.get('oauth2.allowedIndices'))) {
+        esRequestInterceptor(server);
+      }
     }
   });
 };


### PR DESCRIPTION
https://github.com/appuri/kibana-oauth2-plugin/blob/master/server/lib/kibana_index_interceptor.js#L5 ends up in a null reference exception if `oauth2.allowedIndicies` is missing.

Conditionally require the interceptor will fix it, as it does nothing without that configuration.